### PR TITLE
Adds hours/days to defence and max cloak timeouts

### DIFF
--- a/src/main/java/net/mindoth/skillcloaks/item/cloak/DefenceCloakItem.java
+++ b/src/main/java/net/mindoth/skillcloaks/item/cloak/DefenceCloakItem.java
@@ -134,14 +134,25 @@ public class DefenceCloakItem extends CurioItem {
             CompoundTag data = playerData.getCompound(Player.PERSISTED_NBT_TAG);
             if ( !player.level().isClientSide && ( data.getInt(TAG_DEFENCE_COOLDOWN) > 0 ) ) {
                 int totalSecs = data.getInt(TAG_DEFENCE_COOLDOWN) / 20;
+                int days = totalSecs / 86400;
+                int hours = (totalSecs % 86400) / 3600;
                 int mins = (totalSecs % 3600) / 60;
                 int secs = totalSecs % 60;
-                if ( mins > 0 ) {
+
+                if (days > 0) {
+                    player.displayClientMessage(Component.translatable("message.skillcloaks.defence.cooldown")
+                            .append(Component.literal(days + "d " + hours + "h " + mins + "m " + secs + "s")), true);
+                } else if (hours > 0) {
+                    player.displayClientMessage(Component.translatable("message.skillcloaks.defence.cooldown")
+                            .append(Component.literal(hours + "h " + mins + "m " + secs + "s")), true);
+                } else if (mins > 0) {
                     player.displayClientMessage(Component.translatable("message.skillcloaks.defence.cooldown")
                             .append(Component.literal(mins + "m " + secs + "s")), true);
+                } else {
+                    player.displayClientMessage(Component.translatable("message.skillcloaks.defence.cooldown")
+                            .append(Component.literal(secs + "s")), true);
                 }
-                else player.displayClientMessage(Component.translatable("message.skillcloaks.defence.cooldown")
-                        .append(Component.literal( secs + "s")), true);
+
                 player.playNotifySound(SoundEvents.NOTE_BLOCK_SNARE.get(), SoundSource.PLAYERS, 1, 0.5f);
             }
         }

--- a/src/main/java/net/mindoth/skillcloaks/item/cloak/MaxCloakItem.java
+++ b/src/main/java/net/mindoth/skillcloaks/item/cloak/MaxCloakItem.java
@@ -72,14 +72,25 @@ public class MaxCloakItem extends CurioItem {
             CompoundTag data = playerData.getCompound(Player.PERSISTED_NBT_TAG);
             if ( !player.level().isClientSide && ( data.getInt(TAG_DEFENCE_COOLDOWN) > 0 ) ) {
                 int totalSecs = data.getInt(TAG_DEFENCE_COOLDOWN) / 20;
+                int days = totalSecs / 86400;
+                int hours = (totalSecs % 86400) / 3600;
                 int mins = (totalSecs % 3600) / 60;
                 int secs = totalSecs % 60;
-                if ( mins > 0 ) {
+
+                if (days > 0) {
+                    player.displayClientMessage(Component.translatable("message.skillcloaks.defence.cooldown")
+                            .append(Component.literal(days + "d " + hours + "h " + mins + "m " + secs + "s")), true);
+                } else if (hours > 0) {
+                    player.displayClientMessage(Component.translatable("message.skillcloaks.defence.cooldown")
+                            .append(Component.literal(hours + "h " + mins + "m " + secs + "s")), true);
+                } else if (mins > 0) {
                     player.displayClientMessage(Component.translatable("message.skillcloaks.defence.cooldown")
                             .append(Component.literal(mins + "m " + secs + "s")), true);
+                } else {
+                    player.displayClientMessage(Component.translatable("message.skillcloaks.defence.cooldown")
+                            .append(Component.literal(secs + "s")), true);
                 }
-                else player.displayClientMessage(Component.translatable("message.skillcloaks.defence.cooldown")
-                        .append(Component.literal( secs + "s")), true);
+
                 player.playNotifySound(SoundEvents.NOTE_BLOCK_SNARE.get(), SoundSource.PLAYERS, 1, 0.5f);
             }
         }


### PR DESCRIPTION
Apologies for the unsolicited PR, but it was causing some frustrating among my server players that the Defence Cloak timeouts weren't displaying correctly if the timeout was higher than an hour. 

